### PR TITLE
Adds LINQ with 20 examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,152 @@
+# Standard .NET and Visual Studio files/directories
+[Bb]in/
+[Oo]bj/
+[Ll]ogs/
+[Pp]ackages/
+[Tt]est[Rr]esults/
+.vs/
+
+# OS specific files
+# macOS
+.DS_Store
+# Windows
+Thumbs.db
+Desktop.ini
+# Linux
+.directory
+.*.sw?
+.bash_history
+# Temporary files
+*~
+
+# Generated files
+*.user
+*.userosscache
+*.suo
+*.userprefs
+*.pidb
+*.cache
+*.vsp
+*.vspscc
+*_i.c
+*_p.c
+*.ncb
+*.sln.docstates
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUNIT
+*.VisualState.xml
+TestResult.xml
+
+# BenchmarkDotNet Artifacts
+BenchmarkDotNet.Artifacts/
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# ASP.NET Scaffolding
+ScaffoldingReadMe.txt
+
+# Files built by Visual Studio
+*_i.h
+*_p.h
+*_i.cpp
+*_p.cpp
+*_h.h
+*_h.cpp
+*_i.cs
+*_p.cs
+*.dbmdl
+*.dbproj.schemaview
+*.jfm
+*.pfx
+*.publishsettings
+orleans.codegen.cs
+
+# Visual Studio code coverage results
+*.coverage
+*.coveragexml
+
+# DocProject is a documentation generator add-in
+DocProject/buildhelp/
+DocProject/Help/Html2
+DocProject/Help/html
+
+# Click-Once directory
+publish/
+
+# Publish Web Output
+*.[Pp]ublish.xml
+*.azurePubxml
+# Note: Comment the next line if you want to checkin your web deploy settings,
+# but database connection strings (with potential passwords) will be unencrypted
+*.pubxml
+*.publishproj
+
+# NuGet Packages Directory
+*.nupkg
+**/[Pp]ackages/*
+!**/[Pp]ackages/build/
+*.nuget.props
+*.nuget.targets
+
+# Microsoft Azure Build Output
+csx/
+*.build.csdef
+
+# Microsoft Azure Emulator
+ecf/
+rcf/
+
+# Windows Store app package directories and files
+AppPackages/
+BundleArtifacts/
+Package.StoreAssociation.xml
+_pkginfo.txt
+*.appx
+*.appxbundle
+*.appxupload
+
+# Visual Studio cache files
+*.[Cc]ache
+!*.[Cc]ache/
+
+# Others
+ClientBin/
+~$*
+*~
+*.dbmdl
+*.dbproj.schemaview
+*.jfm
+*.pfx
+*.publishsettings
+orleans.codegen.cs
+
+# Including strong name files can present a security risk
+*.snk
+
+# RIA/Silverlight projects
+Generated_Code/
+
+# Backup & report files from converting an old project file to a newer
+_UpgradeReport_Files/
+Backup*/
+UpgradeLog*.XML
+UpgradeLog*.htm
+ServiceFabricBackup/
+*.rptproj.bak
+
+# SQL Server files
+*.mdf
+*.ldf
+*.ndf
+
+# Business Intelligence projects
+*.rdl.data
+*.bim.layout
+*.bim_*.settings

--- a/ToolKit.sln
+++ b/ToolKit.sln
@@ -1,0 +1,27 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{F14CCAEA-8AC7-4CA6-B8B2-0CF7669E9D6F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LINQ", "src\LINQ\LINQ.csproj", "{68D6D4A1-33FC-452A-B9B0-31E3A0E4DD09}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{68D6D4A1-33FC-452A-B9B0-31E3A0E4DD09}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{68D6D4A1-33FC-452A-B9B0-31E3A0E4DD09}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{68D6D4A1-33FC-452A-B9B0-31E3A0E4DD09}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{68D6D4A1-33FC-452A-B9B0-31E3A0E4DD09}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{68D6D4A1-33FC-452A-B9B0-31E3A0E4DD09} = {F14CCAEA-8AC7-4CA6-B8B2-0CF7669E9D6F}
+	EndGlobalSection
+EndGlobal

--- a/src/LINQ/LINQ.cs
+++ b/src/LINQ/LINQ.cs
@@ -1,0 +1,178 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LINQ
+{
+    class LINQ
+    {
+        static void Main(string[] args)
+        {
+            // General tips:
+            // LINQ methods are lazy, meaning they don't execute until you iterate over them.
+            // You can chain multiple LINQ methods together.
+            // LINQ methods are extension methods, so they are called on an IEnumerable<T> object.
+            // If you need to tell if a LINQ query operate in-place, check for a void return type.
+
+            // Sample data
+            var numbers = new List<int> { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            var words = new List<string> { "apple", "banana", "cherry", "elderberry", "date" };
+            var moreNumbers = new List<int> { 5, 6, 7, 8 };
+            var duplicateNumbers = new List<int> { 1, 2, 2, 3, 4, 4, 5 };
+
+            Console.WriteLine("The following data structures are used in this example:");
+            Console.WriteLine("numbers: " + string.Join(", ", numbers));
+            Console.WriteLine("words: " + string.Join(", ", words));
+            Console.WriteLine("moreNumbers: " + string.Join(", ", moreNumbers));
+            Console.WriteLine("duplicateNumbers: " + string.Join(", ", duplicateNumbers));
+            Console.WriteLine();
+
+            // 1. Where: Filter elements
+            // Uses the modulo operator to check if a number is even.
+            // .Where() uses this lambda expression to filter the numbers list.
+            Console.WriteLine(".Where()");
+            var evenNumbers = numbers.Where(n => n % 2 == 0);
+            Console.WriteLine("Even numbers: " + string.Join(", ", evenNumbers));
+            Console.WriteLine();
+
+            // 2. Select: Transform elements
+            // Multiplies each number by itself.
+            // In this case, .Select() acts on every element in the numbers list.
+            Console.WriteLine(".Select()");
+            var squaredNumbers = numbers.Select(n => n * n);
+            Console.WriteLine("Squared numbers: " + string.Join(", ", squaredNumbers));
+            Console.WriteLine();
+
+            // 3. OrderBy: Sort ascending
+            // Linq provides a method to sort, but does not sort in place.
+            // By default, it sorts in ascending order.
+            Console.WriteLine(".OrderBy()");
+            var sortedWords = words.OrderBy(w => w);
+            Console.WriteLine("Sorted words: " + string.Join(", ", sortedWords));
+            Console.WriteLine();
+
+            // 4. OrderByDescending: Sort descending
+            // This method sorts in descending order.
+            Console.WriteLine(".OrderByDescending()");
+            var reverseSortedWords = words.OrderByDescending(w => w);
+            Console.WriteLine("Reverse sorted words: " + string.Join(", ", reverseSortedWords));
+            Console.WriteLine();
+
+            // 5. GroupBy: Group elements
+            // Groups elements by a given assessor.
+            // In this case by their length.
+            Console.WriteLine(".GroupBy()");
+            var groupedByLength = words.GroupBy(w => w.Length);
+            foreach (var group in groupedByLength)
+            {
+                Console.WriteLine($"Words of length {group.Key}: {string.Join(", ", group)}");
+            }
+            Console.WriteLine();
+
+            // 6. Aggregate: Perform accumulation
+            // Aggregation refers to the process of combining
+            // multiple elements into a single result.
+            // In this case, it concatenates all the words.
+            Console.WriteLine(".Aggregate()");
+            var sentence = words.Aggregate((current, next) => current + next);
+            Console.WriteLine("Concatenated words: " + sentence);
+            Console.WriteLine();
+
+            // 7. Any: Check if any element meets a condition
+            // Checks the entire collection against a condition for any fits.
+            Console.WriteLine(".Any()");
+            bool hasShortWord = words.Any(w => w.Length < 5);
+            Console.WriteLine("There are words shorter than 5 char: " + hasShortWord);
+            Console.WriteLine();
+
+            // 8. All: Check if all elements meet a condition
+            // Checks the entire collection against a condition for even one single fit.
+            Console.WriteLine(".All()");    
+            bool allLongWords = words.All(w => w.Length > 3);
+            Console.WriteLine("There are words longer than 3 char: " + allLongWords);
+            Console.WriteLine();
+
+            // 9. Count: Count elements
+            // Counts the number of elements in the collection.
+            Console.WriteLine(".Count()");
+            int countWords = words.Count();
+            Console.WriteLine("Number of words: " + countWords);
+            Console.WriteLine();
+
+            // 10. First: Get first element
+            // Gets the first element in the collection.
+            Console.WriteLine(".First()");
+            Console.WriteLine("First word in words: " + words.First());
+            Console.WriteLine();
+
+            // 11. FirstOrDefault: Get first element or default
+            // Either gets the first element that satisfies a condition, or returns
+            // the default value, which is usually but may not be null.
+            Console.WriteLine(".FirstOrDefault()");
+            Console.WriteLine("First word in words with 'z' or default: " 
+                + words.FirstOrDefault(w => w.Contains('z')) ?? "None");
+            Console.WriteLine();        
+
+            // 12. Last: Get last element
+            // Gets the last element in the collection.
+            Console.WriteLine(".Last()");
+            Console.WriteLine("Last word in words: " + words.Last());
+            Console.WriteLine();
+
+            // 13. LastOrDefault: Get last element or default
+            // Either gets the last element that satisfies a condition, or returns
+            // the default value, which is usually but may not be null.
+            Console.WriteLine(".LastOrDefault()");
+            Console.WriteLine("Last word in words with 'z' or default: " 
+                + words.LastOrDefault(w => w.Contains('z')) ?? "None");
+            Console.WriteLine();
+
+            // 14. Take: Take first N elements
+            // Grabs a specified number of elements from the start of the collection.
+            Console.WriteLine(".Take()");
+            Console.WriteLine("First 3 words: " + string.Join(", ", words.Take(3)));
+            Console.WriteLine();
+
+            // 15. Skip: Skip first N elements
+            // Starts at the specified index and returns the rest of the collection.
+            Console.WriteLine(".Skip()");
+            Console.WriteLine("Skip first 2 words: " + string.Join(", ", words.Skip(2)));
+            Console.WriteLine();
+
+            // 16. Distinct: Remove duplicates
+            // Dedupes a collection.
+            Console.WriteLine(".Distinct()");
+            Console.WriteLine("Unique numbers in duplicateNumbers: " 
+                + string.Join(", ", duplicateNumbers.Distinct()));
+            Console.WriteLine();
+
+            // 17. Union: Combine lists without duplicates
+            // Gets the unique elements between two collections.
+            Console.WriteLine(".Union()");
+            Console.WriteLine("Union of numbers and moreNumbers: " 
+                + string.Join(", ", numbers.Union(moreNumbers)));
+            Console.WriteLine();
+
+            // 18. Intersect: Common elements in lists
+            // Gets the common elements between two collections.
+            Console.WriteLine(".Intersect()");
+            Console.WriteLine("Intersection of numbers and moreNumbers: " 
+                + string.Join(", ", numbers.Intersect(moreNumbers)));
+            Console.WriteLine();
+
+            // 19. Except: Elements in first list but not in second
+            // Gets the elements in the first collection that are not in the second.
+            Console.WriteLine(".Except()");
+            Console.WriteLine("Numbers in numbers but not in moreNumbers: " 
+                + string.Join(", ", numbers.Except(moreNumbers)));
+            Console.WriteLine();
+
+            // 20. Zip: Combine two lists element-wise
+            // Combines two collections into a single collection of pairs.
+            Console.WriteLine(".Zip()");
+            var zippedList = numbers.Zip(words, (num, word) => $"{num}: {word}");
+            Console.WriteLine("Zipped list of numbers and words: " 
+                + string.Join(", ", zippedList));
+        }
+    }
+}

--- a/src/LINQ/LINQ.csproj
+++ b/src/LINQ/LINQ.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
# Overview

Includes the LINQ module with a runtime that enumerates 20 examples of LINQ toolsets.

# Testing

```shell
~/Dropbox/Programming/DotNet.InterviewPrep.ToolKit/src/LINQ - dotnet run --project LINQ.csproj
The following data structures are used in this example:
numbers: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
words: apple, banana, cherry, elderberry, date
moreNumbers: 5, 6, 7, 8
duplicateNumbers: 1, 2, 2, 3, 4, 4, 5

.Where()
Even numbers: 2, 4, 6, 8, 10

.Select()
Squared numbers: 1, 4, 9, 16, 25, 36, 49, 64, 81, 100

.OrderBy()
Sorted words: apple, banana, cherry, date, elderberry

.OrderByDescending()
Reverse sorted words: elderberry, date, cherry, banana, apple

.GroupBy()
Words of length 5: apple
Words of length 6: banana, cherry
Words of length 10: elderberry
Words of length 4: date

.Aggregate()
Concatenated words: applebananacherryelderberrydate

.Any()
There are words shorter than 5 char: True

.All()
There are words longer than 3 char: True

.Count()
Number of words: 5

.First()
First word in words: apple

.FirstOrDefault()
First word in words with 'z' or default: 

.Last()
Last word in words: date

.LastOrDefault()
Last word in words with 'z' or default: 

.Take()
First 3 words: apple, banana, cherry

.Skip()
Skip first 2 words: cherry, elderberry, date

.Distinct()
Unique numbers in duplicateNumbers: 1, 2, 3, 4, 5

.Union()
Union of numbers and moreNumbers: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10

.Intersect()
Intersection of numbers and moreNumbers: 5, 6, 7, 8

.Except()
Numbers in numbers but not in moreNumbers: 1, 2, 3, 4, 9, 10

.Zip()
Zipped list of numbers and words: 1: apple, 2: banana, 3: cherry, 4: elderberry, 5: date
```